### PR TITLE
Phase 2/feat 10

### DIFF
--- a/lib/data/di/module/network_module.dart
+++ b/lib/data/di/module/network_module.dart
@@ -3,8 +3,10 @@ import 'package:mobile_ai_erp/core/data/network/dio/dio_client.dart';
 import 'package:mobile_ai_erp/core/data/network/dio/interceptors/auth_interceptor.dart';
 import 'package:mobile_ai_erp/core/data/network/dio/interceptors/logging_interceptor.dart';
 import 'package:mobile_ai_erp/data/network/apis/posts/post_api.dart';
+import 'package:mobile_ai_erp/data/network/apis/web_builder/web_builder_api.dart';
 import 'package:mobile_ai_erp/data/network/constants/endpoints.dart';
 import 'package:mobile_ai_erp/data/network/interceptors/error_interceptor.dart';
+import 'package:mobile_ai_erp/data/network/interceptors/tenant_interceptor.dart';
 import 'package:mobile_ai_erp/data/network/rest_client.dart';
 import 'package:mobile_ai_erp/data/sharedpref/shared_preference_helper.dart';
 import 'package:event_bus/event_bus.dart';
@@ -12,6 +14,8 @@ import 'package:event_bus/event_bus.dart';
 import '../../../di/service_locator.dart';
 
 class NetworkModule {
+  static const String erpDioClientName = 'erpDioClient';
+
   static Future<void> configureNetworkModuleInjection() async {
     // event bus:---------------------------------------------------------------
     getIt.registerSingleton<EventBus>(EventBus());
@@ -24,16 +28,19 @@ class NetworkModule {
         accessToken: () async => await getIt<SharedPreferenceHelper>().authToken,
       ),
     );
+    getIt.registerSingleton<TenantInterceptor>(
+      TenantInterceptor(Endpoints.tenantId),
+    );
 
     // rest client:-------------------------------------------------------------
     getIt.registerSingleton(RestClient());
 
-    // dio:---------------------------------------------------------------------
+    // dio (legacy posts API):--------------------------------------------------
     getIt.registerSingleton<DioConfigs>(
       const DioConfigs(
         baseUrl: Endpoints.baseUrl,
         connectionTimeout: Endpoints.connectionTimeout,
-        receiveTimeout:Endpoints.receiveTimeout,
+        receiveTimeout: Endpoints.receiveTimeout,
       ),
     );
     getIt.registerSingleton<DioClient>(
@@ -47,7 +54,25 @@ class NetworkModule {
         ),
     );
 
+    // dio (ERP backend - separate base URL + tenant header):-------------------
+    final erpDioClient = DioClient(
+      dioConfigs: const DioConfigs(
+        baseUrl: Endpoints.erpBaseUrl,
+        connectionTimeout: Endpoints.connectionTimeout,
+        receiveTimeout: Endpoints.receiveTimeout,
+      ),
+    )..addInterceptors([
+        getIt<AuthInterceptor>(),
+        getIt<TenantInterceptor>(),
+        getIt<ErrorInterceptor>(),
+        getIt<LoggingInterceptor>(),
+      ]);
+    getIt.registerSingleton<DioClient>(erpDioClient, instanceName: erpDioClientName);
+
     // api's:-------------------------------------------------------------------
     getIt.registerSingleton(PostApi(getIt<DioClient>(), getIt<RestClient>()));
+    getIt.registerSingleton<WebBuilderApi>(
+      WebBuilderApi(getIt<DioClient>(instanceName: erpDioClientName)),
+    );
   }
 }

--- a/lib/data/di/module/repository_module.dart
+++ b/lib/data/di/module/repository_module.dart
@@ -9,6 +9,7 @@ import 'package:mobile_ai_erp/data/local/datasources/product_metadata/product_me
 import 'package:mobile_ai_erp/data/local/datasources/user/role_datasource.dart';
 import 'package:mobile_ai_erp/data/local/datasources/user/user_datasource.dart';
 import 'package:mobile_ai_erp/data/network/apis/posts/post_api.dart';
+import 'package:mobile_ai_erp/data/network/apis/web_builder/web_builder_api.dart';
 import 'package:mobile_ai_erp/data/repository/checkout/checkout_repository_impl.dart';
 import 'package:mobile_ai_erp/data/repository/customer/customer_repository_impl.dart';
 import 'package:mobile_ai_erp/data/repository/dashboard/mock_dashboard_repository.dart';
@@ -126,10 +127,10 @@ class RepositoryModule {
       () => CmsPageRepositoryImpl(),
     );
     getIt.registerLazySingleton<WebThemeRepository>(
-      () => WebThemeRepositoryImpl(),
+      () => WebThemeRepositoryImpl(getIt<WebBuilderApi>()),
     );
     getIt.registerLazySingleton<StoreSettingsRepository>(
-      () => StoreSettingsRepositoryImpl(),
+      () => StoreSettingsRepositoryImpl(getIt<WebBuilderApi>()),
     );
 
     getIt.registerLazySingleton<SupplierRepository>(() => SupplierMockRepository());

--- a/lib/data/di/module/repository_module.dart
+++ b/lib/data/di/module/repository_module.dart
@@ -124,7 +124,7 @@ class RepositoryModule {
 
     // web_builder:--------------------------------------------------------------
     getIt.registerLazySingleton<CmsPageRepository>(
-      () => CmsPageRepositoryImpl(),
+      () => CmsPageRepositoryImpl(getIt<WebBuilderApi>()),
     );
     getIt.registerLazySingleton<WebThemeRepository>(
       () => WebThemeRepositoryImpl(getIt<WebBuilderApi>()),

--- a/lib/data/network/apis/web_builder/web_builder_api.dart
+++ b/lib/data/network/apis/web_builder/web_builder_api.dart
@@ -1,0 +1,104 @@
+import 'package:mobile_ai_erp/core/data/network/dio/dio_client.dart';
+import 'package:mobile_ai_erp/data/network/constants/endpoints.dart';
+
+class WebBuilderApi {
+  final DioClient _dioClient;
+
+  WebBuilderApi(this._dioClient);
+
+  // ─── Store Settings ──────────────────────────────────────────────────────
+
+  Future<Map<String, dynamic>> getStoreSettings() async {
+    final res = await _dioClient.dio.get(Endpoints.storeSettings);
+    return Map<String, dynamic>.from(res.data as Map);
+  }
+
+  Future<Map<String, dynamic>> updateStoreSettings(
+    Map<String, dynamic> body,
+  ) async {
+    final res = await _dioClient.dio.patch(
+      Endpoints.storeSettings,
+      data: body,
+    );
+    return Map<String, dynamic>.from(res.data as Map);
+  }
+
+  // ─── CMS Pages ───────────────────────────────────────────────────────────
+
+  Future<Map<String, dynamic>> getCmsPages({
+    int page = 1,
+    int pageSize = 50,
+    String? search,
+    String? status,
+  }) async {
+    final res = await _dioClient.dio.get(
+      Endpoints.cmsPages,
+      queryParameters: {
+        'page': page,
+        'pageSize': pageSize,
+        if (search != null && search.isNotEmpty) 'search': search,
+        if (status != null && status.isNotEmpty) 'status': status,
+      },
+    );
+    return Map<String, dynamic>.from(res.data as Map);
+  }
+
+  Future<Map<String, dynamic>> getCmsPageById(String id) async {
+    final res = await _dioClient.dio.get(Endpoints.cmsPageById(id));
+    return Map<String, dynamic>.from(res.data as Map);
+  }
+
+  Future<Map<String, dynamic>> createCmsPage(Map<String, dynamic> body) async {
+    final res = await _dioClient.dio.post(Endpoints.cmsPages, data: body);
+    return Map<String, dynamic>.from(res.data as Map);
+  }
+
+  Future<Map<String, dynamic>> updateCmsPage(
+    String id,
+    Map<String, dynamic> body,
+  ) async {
+    final res = await _dioClient.dio.patch(
+      Endpoints.cmsPageById(id),
+      data: body,
+    );
+    return Map<String, dynamic>.from(res.data as Map);
+  }
+
+  Future<void> deleteCmsPage(String id) async {
+    await _dioClient.dio.delete(Endpoints.cmsPageById(id));
+  }
+
+  Future<Map<String, dynamic>> publishCmsPage(String id, bool published) async {
+    final res = await _dioClient.dio.post(
+      Endpoints.cmsPagePublish(id),
+      data: {'published': published},
+    );
+    return Map<String, dynamic>.from(res.data as Map);
+  }
+
+  // ─── Themes ──────────────────────────────────────────────────────────────
+
+  Future<List<dynamic>> getThemes({String? category}) async {
+    final res = await _dioClient.dio.get(
+      Endpoints.themes,
+      queryParameters: {
+        if (category != null && category.isNotEmpty) 'category': category,
+      },
+    );
+    return List<dynamic>.from(res.data as List);
+  }
+
+  Future<Map<String, dynamic>?> getActiveTheme() async {
+    final res = await _dioClient.dio.get(Endpoints.activeTheme);
+    if (res.data == null) return null;
+    return Map<String, dynamic>.from(res.data as Map);
+  }
+
+  Future<Map<String, dynamic>> setActiveTheme(String themeId) async {
+    final res = await _dioClient.dio.patch(
+      Endpoints.activeTheme,
+      data: {'themeId': themeId},
+    );
+    return Map<String, dynamic>.from(res.data as Map);
+  }
+}

--- a/lib/data/network/constants/endpoints.dart
+++ b/lib/data/network/constants/endpoints.dart
@@ -1,15 +1,40 @@
 class Endpoints {
   Endpoints._();
 
-  // base url
+  // base url (legacy - sample posts API)
   static const String baseUrl = "http://jsonplaceholder.typicode.com";
 
-  // receiveTimeout
-  static const int receiveTimeout = 15000;
+  // ERP backend base url - override at build time:
+  //   --dart-define=ERP_BASE_URL=http://10.0.2.2:3000
+  static const String erpBaseUrl = String.fromEnvironment(
+    'ERP_BASE_URL',
+    defaultValue: 'http://10.0.2.2:3000',
+  );
 
-  // connectTimeout
+  // Tenant id sent via X-Tenant-Id header to ERP backend.
+  // Override at build time:
+  //   --dart-define=TENANT_ID=<uuid>
+  static const String tenantId = String.fromEnvironment(
+    'TENANT_ID',
+    defaultValue: '00000000-0000-0000-0000-000000000000',
+  );
+
+  // timeouts
+  static const int receiveTimeout = 15000;
   static const int connectionTimeout = 30000;
 
-  // booking endpoints
+  // legacy posts endpoint
   static const String getPosts = baseUrl + "/posts";
+
+  // web builder - store settings
+  static const String storeSettings = "/store-settings";
+
+  // web builder - cms pages
+  static const String cmsPages = "/cms-pages";
+  static String cmsPageById(String id) => "/cms-pages/$id";
+  static String cmsPagePublish(String id) => "/cms-pages/$id/publish";
+
+  // web builder - themes
+  static const String themes = "/themes";
+  static const String activeTheme = "/themes/active";
 }

--- a/lib/data/network/interceptors/tenant_interceptor.dart
+++ b/lib/data/network/interceptors/tenant_interceptor.dart
@@ -1,0 +1,29 @@
+import 'dart:developer' as developer;
+
+import 'package:dio/dio.dart';
+
+class TenantInterceptor extends Interceptor {
+  static const String _placeholderTenantId =
+      '00000000-0000-0000-0000-000000000000';
+
+  final String tenantId;
+
+  TenantInterceptor(this.tenantId) {
+    if (tenantId.isEmpty || tenantId == _placeholderTenantId) {
+      developer.log(
+        'TenantInterceptor initialised with placeholder tenant id. '
+        'Pass a real tenant via --dart-define=TENANT_ID=<uuid> '
+        'or ERP API calls will fail with 401/403.',
+        name: 'TenantInterceptor',
+      );
+    }
+  }
+
+  @override
+  void onRequest(RequestOptions options, RequestInterceptorHandler handler) {
+    if (tenantId.isNotEmpty) {
+      options.headers.putIfAbsent('X-Tenant-Id', () => tenantId);
+    }
+    super.onRequest(options, handler);
+  }
+}

--- a/lib/data/repository/web_builder/cms_page_repository_impl.dart
+++ b/lib/data/repository/web_builder/cms_page_repository_impl.dart
@@ -1,131 +1,115 @@
 import 'dart:async';
 
+import 'package:dio/dio.dart';
+import 'package:mobile_ai_erp/data/network/apis/web_builder/web_builder_api.dart';
 import 'package:mobile_ai_erp/domain/entity/web_builder/cms_page.dart';
 import 'package:mobile_ai_erp/domain/entity/web_builder/cms_page_list.dart';
 import 'package:mobile_ai_erp/domain/entity/web_builder/content_block.dart';
 import 'package:mobile_ai_erp/domain/repository/web_builder/cms_page_repository.dart';
 
+class CmsPageStatus {
+  CmsPageStatus._();
+  static const String published = 'Published';
+  static const String draft = 'Draft';
+}
+
 class CmsPageRepositoryImpl extends CmsPageRepository {
-  final List<CmsPage> _mockPages = [
-    CmsPage(
-      id: '1',
-      title: 'Home Page',
-      description:
-          'Main landing page with hero banner, featured products, and promotions',
-      type: 'Landing',
-      status: 'Published',
-      lastModified: DateTime(2026, 3, 15),
-      isPublished: true,
-      blocks: [
-        ContentBlock(type: 'hero', title: 'Hero Banner'),
-        ContentBlock(type: 'products', title: 'Product Showcase'),
-        ContentBlock(type: 'cta', title: 'Call to Action'),
-      ],
-      metaTitle: 'Jarvis Store — Smart Shopping',
-      metaDescription: 'Welcome to Jarvis Store. Discover the best products.',
-      slug: 'home',
-    ),
-    CmsPage(
-      id: '2',
-      title: 'About Us',
-      description: 'Company story, mission, and team introduction',
-      type: 'Info',
-      status: 'Published',
-      lastModified: DateTime(2026, 3, 10),
-      isPublished: true,
-      blocks: [
-        ContentBlock(type: 'hero', title: 'Hero Banner'),
-        ContentBlock(type: 'text', title: 'Our Story'),
-        ContentBlock(type: 'gallery', title: 'Team Photos'),
-      ],
-      metaTitle: 'About Us — Jarvis Store',
-      metaDescription: 'Learn about our mission and team.',
-      slug: 'about-us',
-    ),
-    CmsPage(
-      id: '3',
-      title: 'Contact',
-      description: 'Contact form, store locations, and business hours',
-      type: 'Info',
-      status: 'Draft',
-      lastModified: DateTime(2026, 3, 18),
-      isPublished: false,
-      blocks: [
-        ContentBlock(type: 'text', title: 'Contact Info'),
-        ContentBlock(type: 'cta', title: 'Send Message'),
-      ],
-      metaTitle: 'Contact Us — Jarvis Store',
-      metaDescription: 'Get in touch with our team.',
-      slug: 'contact',
-    ),
-    CmsPage(
-      id: '4',
-      title: 'Spring Sale 2026',
-      description:
-          'Seasonal promotion page with countdown timer and featured deals',
-      type: 'Marketing',
-      status: 'Published',
-      lastModified: DateTime(2026, 3, 20),
-      isPublished: true,
-      blocks: [
-        ContentBlock(type: 'hero', title: 'Sale Banner'),
-        ContentBlock(type: 'products', title: 'Featured Deals'),
-        ContentBlock(type: 'cta', title: 'Shop Now'),
-      ],
-      metaTitle: 'Spring Sale 2026 — Up to 50% Off',
-      metaDescription: "Don't miss our biggest sale of the season!",
-      slug: 'spring-sale-2026',
-    ),
-    CmsPage(
-      id: '5',
-      title: 'FAQ',
-      description:
-          'Frequently asked questions about shipping, returns, and payments',
-      type: 'Support',
-      status: 'Draft',
-      lastModified: DateTime(2026, 3, 12),
-      isPublished: false,
-      blocks: [
-        ContentBlock(type: 'text', title: 'Shipping Questions'),
-        ContentBlock(type: 'text', title: 'Return Policy'),
-        ContentBlock(type: 'text', title: 'Payment Methods'),
-      ],
-      metaTitle: 'FAQ — Jarvis Store',
-      metaDescription: 'Find answers to common questions.',
-      slug: 'faq',
-    ),
-  ];
+  final WebBuilderApi _api;
+
+  CmsPageRepositoryImpl(this._api);
 
   @override
   Future<CmsPageList> getPages() async {
-    await Future.delayed(const Duration(milliseconds: 500));
-    return CmsPageList(pages: List.from(_mockPages));
+    final res = await _api.getCmsPages(pageSize: 100);
+    final data = (res['data'] as List?) ?? const [];
+    final pages = data
+        .whereType<Map>()
+        .map((m) => _mapFromApi(Map<String, dynamic>.from(m)))
+        .toList();
+    return CmsPageList(pages: pages);
   }
 
   @override
   Future<CmsPage?> getPageById(String id) async {
-    await Future.delayed(const Duration(milliseconds: 300));
     try {
-      return _mockPages.firstWhere((p) => p.id == id);
-    } catch (_) {
-      return null;
+      final json = await _api.getCmsPageById(id);
+      return _mapFromApi(json);
+    } on DioException catch (e) {
+      if (e.response?.statusCode == 404) return null;
+      rethrow;
     }
   }
 
   @override
   Future<void> savePage(CmsPage page) async {
-    await Future.delayed(const Duration(milliseconds: 500));
-    final index = _mockPages.indexWhere((p) => p.id == page.id);
-    if (index >= 0) {
-      _mockPages[index] = page;
+    final body = _mapToApi(page);
+    if (page.id == null || page.id!.isEmpty) {
+      await _api.createCmsPage(body);
     } else {
-      _mockPages.add(page);
+      // server doesn't accept publish state in PATCH — strip if present
+      body.remove('is_published');
+      await _api.updateCmsPage(page.id!, body);
     }
   }
 
   @override
   Future<void> deletePage(String id) async {
-    await Future.delayed(const Duration(milliseconds: 300));
-    _mockPages.removeWhere((p) => p.id == id);
+    await _api.deleteCmsPage(id);
+  }
+
+  @override
+  Future<void> publishPage(String id, bool published) async {
+    await _api.publishCmsPage(id, published);
+  }
+
+  CmsPage _mapFromApi(Map<String, dynamic> json) {
+    final isPublished = json['isPublished'] as bool? ?? false;
+    final updatedAt = json['updatedAt'] as String?;
+    final blocksJson = json['contentBlocks'] as List?;
+    return CmsPage(
+      id: json['id'] as String?,
+      title: json['title'] as String?,
+      description: json['description'] as String?,
+      type: json['pageType'] as String?,
+      status: isPublished ? CmsPageStatus.published : CmsPageStatus.draft,
+      lastModified: updatedAt != null ? DateTime.tryParse(updatedAt) : null,
+      isPublished: isPublished,
+      blocks: blocksJson
+          ?.whereType<Map>()
+          .map(
+            (b) => ContentBlock(
+              type: b['type'] as String?,
+              title: b['title'] as String? ?? b['type'] as String?,
+            ),
+          )
+          .toList(),
+      metaTitle: json['metaTitle'] as String?,
+      metaDescription: json['metaDescription'] as String?,
+      slug: json['urlSlug'] as String?,
+    );
+  }
+
+  Map<String, dynamic> _mapToApi(CmsPage page) {
+    final body = <String, dynamic>{};
+    if (page.title != null) body['title'] = page.title;
+    if (page.description != null) body['description'] = page.description;
+    if (page.type != null) body['page_type'] = page.type;
+    if (page.slug != null) body['url_slug'] = page.slug;
+    if (page.metaTitle != null) body['meta_title'] = page.metaTitle;
+    if (page.metaDescription != null) {
+      body['meta_description'] = page.metaDescription;
+    }
+    if (page.blocks != null) {
+      body['content_blocks'] = page.blocks!
+          .asMap()
+          .entries
+          .map((e) => {
+                'type': e.value.type,
+                'title': e.value.title,
+                'order': e.key,
+              })
+          .toList();
+    }
+    return body;
   }
 }

--- a/lib/data/repository/web_builder/store_settings_repository_impl.dart
+++ b/lib/data/repository/web_builder/store_settings_repository_impl.dart
@@ -1,29 +1,48 @@
 import 'dart:async';
 
+import 'package:mobile_ai_erp/data/network/apis/web_builder/web_builder_api.dart';
 import 'package:mobile_ai_erp/domain/entity/web_builder/store_settings.dart';
 import 'package:mobile_ai_erp/domain/repository/web_builder/store_settings_repository.dart';
 
 class StoreSettingsRepositoryImpl extends StoreSettingsRepository {
-  StoreSettings _mockSettings = StoreSettings(
-    storeName: 'Jarvis Store',
-    tagline: 'Smart Shopping, Simplified',
-    email: 'contact@jarvisstore.com',
-    phone: '+84 123 456 789',
-    address: '227 Nguyen Van Cu, District 5, HCMC',
-    currency: 'VND',
-    description:
-        'Your one-stop shop for electronics, accessories, and smart home devices.',
-  );
+  final WebBuilderApi _api;
+
+  StoreSettingsRepositoryImpl(this._api);
 
   @override
   Future<StoreSettings> getSettings() async {
-    await Future.delayed(const Duration(milliseconds: 500));
-    return _mockSettings;
+    final json = await _api.getStoreSettings();
+    return _mapFromApi(json);
   }
 
   @override
   Future<void> saveSettings(StoreSettings settings) async {
-    await Future.delayed(const Duration(milliseconds: 500));
-    _mockSettings = settings;
+    await _api.updateStoreSettings(_mapToApi(settings));
+  }
+
+  StoreSettings _mapFromApi(Map<String, dynamic> json) {
+    return StoreSettings(
+      storeName: json['name'] as String?,
+      tagline: json['tagline'] as String?,
+      email: json['contactEmail'] as String?,
+      phone: json['contactPhone'] as String?,
+      address: json['address'] as String?,
+      currency: json['currency'] as String?,
+      description: json['description'] as String?,
+      logoUrl: json['logoUrl'] as String?,
+    );
+  }
+
+  Map<String, dynamic> _mapToApi(StoreSettings s) {
+    final body = <String, dynamic>{};
+    if (s.storeName != null) body['name'] = s.storeName;
+    if (s.tagline != null) body['tagline'] = s.tagline;
+    if (s.email != null) body['contact_email'] = s.email;
+    if (s.phone != null) body['contact_phone'] = s.phone;
+    if (s.address != null) body['address'] = s.address;
+    if (s.currency != null) body['currency'] = s.currency;
+    if (s.description != null) body['description'] = s.description;
+    if (s.logoUrl != null) body['logo_url'] = s.logoUrl;
+    return body;
   }
 }

--- a/lib/data/repository/web_builder/web_theme_repository_impl.dart
+++ b/lib/data/repository/web_builder/web_theme_repository_impl.dart
@@ -1,131 +1,114 @@
 import 'dart:async';
+import 'dart:developer' as developer;
 
+import 'package:mobile_ai_erp/data/network/apis/web_builder/web_builder_api.dart';
 import 'package:mobile_ai_erp/domain/entity/web_builder/web_theme.dart';
 import 'package:mobile_ai_erp/domain/entity/web_builder/web_theme_list.dart';
 import 'package:mobile_ai_erp/domain/repository/web_builder/web_theme_repository.dart';
 
 class WebThemeRepositoryImpl extends WebThemeRepository {
-  final List<WebTheme> _mockThemes = [
-    WebTheme(
-      id: '1',
-      name: 'Modern Minimal',
-      description: 'Clean and minimalist design with focus on content. '
-          'Perfect for stores that want a professional, distraction-free look.',
-      primaryColor: 0xFF1A1A2E,
-      accentColor: 0xFFE94560,
-      backgroundColor: 0xFFF5F5F5,
-      category: 'Minimal',
-      fonts: ['Inter', 'Roboto'],
-      isActive: true,
-    ),
-    WebTheme(
-      id: '2',
-      name: 'Ocean Breeze',
-      description: 'Fresh blue tones inspired by the sea. '
-          'Great for lifestyle, travel, and wellness brands.',
-      primaryColor: 0xFF0077B6,
-      accentColor: 0xFF00B4D8,
-      backgroundColor: 0xFFCAF0F8,
-      category: 'Nature',
-      fonts: ['Poppins', 'Open Sans'],
-      isActive: false,
-    ),
-    WebTheme(
-      id: '3',
-      name: 'Sunset Glow',
-      description: 'Warm gradient colors for a vibrant storefront. '
-          'Ideal for food, fashion, and creative businesses.',
-      primaryColor: 0xFFFF6B35,
-      accentColor: 0xFFFFC045,
-      backgroundColor: 0xFFFFF8F0,
-      category: 'Vibrant',
-      fonts: ['Montserrat', 'Lato'],
-      isActive: false,
-    ),
-    WebTheme(
-      id: '4',
-      name: 'Dark Elegance',
-      description: 'Sophisticated dark theme with gold accents. '
-          'Perfect for luxury goods, jewelry, and premium brands.',
-      primaryColor: 0xFF2D2D2D,
-      accentColor: 0xFFD4AF37,
-      backgroundColor: 0xFF1A1A1A,
-      category: 'Dark',
-      fonts: ['Playfair Display', 'Cormorant'],
-      isActive: false,
-    ),
-    WebTheme(
-      id: '5',
-      name: 'Forest Green',
-      description: 'Natural earthy tones for eco-friendly brands. '
-          'Ideal for organic, sustainable, and outdoor products.',
-      primaryColor: 0xFF2D6A4F,
-      accentColor: 0xFF95D5B2,
-      backgroundColor: 0xFFF0FFF4,
-      category: 'Nature',
-      fonts: ['Nunito', 'Source Sans Pro'],
-      isActive: false,
-    ),
-    WebTheme(
-      id: '6',
-      name: 'Tech Purple',
-      description: 'Modern tech-inspired purple and neon palette. '
-          'Great for SaaS, gadgets, and digital products.',
-      primaryColor: 0xFF7B2CBF,
-      accentColor: 0xFFC77DFF,
-      backgroundColor: 0xFFF8F0FF,
-      category: 'Vibrant',
-      fonts: ['Space Grotesk', 'JetBrains Mono'],
-      isActive: false,
-    ),
-  ];
+  final WebBuilderApi _api;
+
+  WebThemeRepositoryImpl(this._api);
 
   @override
   Future<WebThemeList> getThemes() async {
-    await Future.delayed(const Duration(milliseconds: 500));
-    return WebThemeList(themes: List.from(_mockThemes));
+    final results = await Future.wait([
+      _api.getThemes(),
+      _api.getActiveTheme(),
+    ]);
+
+    final themesJson = results[0] as List<dynamic>;
+    final activeJson = results[1] as Map<String, dynamic>?;
+    final activeId = activeJson?['themeId'] as String?;
+
+    final themes = themesJson
+        .whereType<Map>()
+        .map((m) => _mapFromApi(
+              Map<String, dynamic>.from(m),
+              isActive: activeId != null && m['id'] == activeId,
+            ))
+        .toList();
+
+    return WebThemeList(themes: themes);
   }
 
   @override
   Future<WebTheme?> getThemeById(String id) async {
-    await Future.delayed(const Duration(milliseconds: 300));
+    // BE has no GET /themes/:id endpoint — fetch full list and pick.
     try {
-      return _mockThemes.firstWhere((t) => t.id == id);
-    } catch (_) {
+      final list = await getThemes();
+      return list.themes!.firstWhere((t) => t.id == id);
+    } on StateError {
+      // firstWhere throws StateError when not found
       return null;
     }
   }
 
   @override
-  Future<void> applyTheme(String id,
-      {int? primaryColor, int? accentColor}) async {
-    await Future.delayed(const Duration(milliseconds: 500));
-    for (var i = 0; i < _mockThemes.length; i++) {
-      if (_mockThemes[i].id == id) {
-        _mockThemes[i] = WebTheme(
-          id: _mockThemes[i].id,
-          name: _mockThemes[i].name,
-          description: _mockThemes[i].description,
-          primaryColor: primaryColor ?? _mockThemes[i].primaryColor,
-          accentColor: accentColor ?? _mockThemes[i].accentColor,
-          backgroundColor: _mockThemes[i].backgroundColor,
-          category: _mockThemes[i].category,
-          fonts: _mockThemes[i].fonts,
-          isActive: true,
-        );
-      } else {
-        _mockThemes[i] = WebTheme(
-          id: _mockThemes[i].id,
-          name: _mockThemes[i].name,
-          description: _mockThemes[i].description,
-          primaryColor: _mockThemes[i].primaryColor,
-          accentColor: _mockThemes[i].accentColor,
-          backgroundColor: _mockThemes[i].backgroundColor,
-          category: _mockThemes[i].category,
-          fonts: _mockThemes[i].fonts,
-          isActive: false,
-        );
-      }
+  Future<void> applyTheme(
+    String id, {
+    int? primaryColor,
+    int? accentColor,
+  }) async {
+    if (primaryColor != null || accentColor != null) {
+      developer.log(
+        'applyTheme: BE does not support color overrides yet — '
+        'primaryColor/accentColor params will be ignored.',
+        name: 'WebThemeRepositoryImpl',
+      );
     }
+    await _api.setActiveTheme(id);
+  }
+
+  WebTheme _mapFromApi(
+    Map<String, dynamic> json, {
+    required bool isActive,
+  }) {
+    final fontHeading = json['fontHeading'] as String?;
+    final fontBody = json['fontBody'] as String?;
+    final fonts = <String>[
+      if (fontHeading != null && fontHeading.isNotEmpty) fontHeading,
+      if (fontBody != null && fontBody.isNotEmpty && fontBody != fontHeading)
+        fontBody,
+    ];
+
+    final category = (json['category'] as String?)?.toLowerCase() ?? '';
+    final primary = _parseHexColor(json['primaryColor'] as String?);
+
+    return WebTheme(
+      id: json['id'] as String?,
+      name: json['name'] as String?,
+      // BE has no description field — leave null. UI may render previewImage instead.
+      description: null,
+      primaryColor: primary,
+      accentColor: _parseHexColor(json['accentColor'] as String?),
+      backgroundColor: _deriveBackgroundColor(primary, category),
+      category: json['category'] as String?,
+      fonts: fonts,
+      isActive: isActive,
+    );
+  }
+
+  /// Parse "#RRGGBB" or "#AARRGGBB" hex into ARGB int. Falls back to opaque black.
+  int _parseHexColor(String? hex) {
+    if (hex == null || hex.isEmpty) return 0xFF000000;
+    var value = hex.replaceFirst('#', '');
+    if (value.length == 6) value = 'FF$value';
+    return int.tryParse(value, radix: 16) ?? 0xFF000000;
+  }
+
+  /// Derive a sensible page background color from the primary color and category.
+  /// Dark themes get a dark neutral; otherwise we tint primary toward white (~92% white).
+  int _deriveBackgroundColor(int primaryArgb, String category) {
+    if (category == 'dark') return 0xFF1A1A1A;
+
+    final r = (primaryArgb >> 16) & 0xFF;
+    final g = (primaryArgb >> 8) & 0xFF;
+    final b = primaryArgb & 0xFF;
+    const blend = 0.92;
+    int mix(int channel) =>
+        (channel + (255 - channel) * blend).clamp(0, 255).toInt();
+    return (0xFF << 24) | (mix(r) << 16) | (mix(g) << 8) | mix(b);
   }
 }

--- a/lib/domain/di/module/usecase_module.dart
+++ b/lib/domain/di/module/usecase_module.dart
@@ -58,6 +58,7 @@ import 'package:mobile_ai_erp/domain/usecase/user/save_login_in_status_usecase.d
 import 'package:mobile_ai_erp/domain/usecase/user/update_role_usercase.dart';
 import 'package:mobile_ai_erp/domain/usecase/web_builder/apply_web_theme_usecase.dart';
 import 'package:mobile_ai_erp/domain/usecase/web_builder/delete_cms_page_usecase.dart';
+import 'package:mobile_ai_erp/domain/usecase/web_builder/publish_cms_page_usecase.dart';
 import 'package:mobile_ai_erp/domain/usecase/web_builder/get_cms_page_by_id_usecase.dart';
 import 'package:mobile_ai_erp/domain/usecase/web_builder/get_cms_pages_usecase.dart';
 import 'package:mobile_ai_erp/domain/usecase/web_builder/get_store_settings_usecase.dart';
@@ -172,6 +173,9 @@ class UseCaseModule {
     );
     getIt.registerSingleton<DeleteCmsPageUseCase>(
       DeleteCmsPageUseCase(getIt<CmsPageRepository>()),
+    );
+    getIt.registerSingleton<PublishCmsPageUseCase>(
+      PublishCmsPageUseCase(getIt<CmsPageRepository>()),
     );
     getIt.registerSingleton<GetWebThemesUseCase>(
       GetWebThemesUseCase(getIt<WebThemeRepository>()),

--- a/lib/domain/repository/web_builder/cms_page_repository.dart
+++ b/lib/domain/repository/web_builder/cms_page_repository.dart
@@ -11,4 +11,6 @@ abstract class CmsPageRepository {
   Future<void> savePage(CmsPage page);
 
   Future<void> deletePage(String id);
+
+  Future<void> publishPage(String id, bool published);
 }

--- a/lib/domain/usecase/web_builder/publish_cms_page_usecase.dart
+++ b/lib/domain/usecase/web_builder/publish_cms_page_usecase.dart
@@ -1,0 +1,20 @@
+import 'package:mobile_ai_erp/core/domain/usecase/use_case.dart';
+import 'package:mobile_ai_erp/domain/repository/web_builder/cms_page_repository.dart';
+
+class PublishCmsPageParams {
+  final String id;
+  final bool published;
+
+  PublishCmsPageParams({required this.id, required this.published});
+}
+
+class PublishCmsPageUseCase extends UseCase<void, PublishCmsPageParams> {
+  final CmsPageRepository _repository;
+
+  PublishCmsPageUseCase(this._repository);
+
+  @override
+  Future<void> call({required PublishCmsPageParams params}) {
+    return _repository.publishPage(params.id, params.published);
+  }
+}

--- a/lib/presentation/di/module/store_module.dart
+++ b/lib/presentation/di/module/store_module.dart
@@ -60,6 +60,7 @@ import 'package:mobile_ai_erp/domain/usecase/web_builder/get_cms_pages_usecase.d
 import 'package:mobile_ai_erp/domain/usecase/web_builder/get_store_settings_usecase.dart';
 import 'package:mobile_ai_erp/domain/usecase/web_builder/get_web_theme_by_id_usecase.dart';
 import 'package:mobile_ai_erp/domain/usecase/web_builder/get_web_themes_usecase.dart';
+import 'package:mobile_ai_erp/domain/usecase/web_builder/publish_cms_page_usecase.dart';
 import 'package:mobile_ai_erp/domain/usecase/web_builder/save_cms_page_usecase.dart';
 import 'package:mobile_ai_erp/domain/usecase/web_builder/save_store_settings_usecase.dart';
 import 'package:mobile_ai_erp/presentation/customer_management/store/customer_store.dart';
@@ -221,6 +222,7 @@ class StoreModule {
         getIt<GetCmsPageByIdUseCase>(),
         getIt<SaveCmsPageUseCase>(),
         getIt<DeleteCmsPageUseCase>(),
+        getIt<PublishCmsPageUseCase>(),
         getIt<ErrorStore>(),
       ),
     );

--- a/lib/presentation/web_builder/store/cms_page_store.dart
+++ b/lib/presentation/web_builder/store/cms_page_store.dart
@@ -4,6 +4,7 @@ import 'package:mobile_ai_erp/domain/entity/web_builder/cms_page_list.dart';
 import 'package:mobile_ai_erp/domain/usecase/web_builder/delete_cms_page_usecase.dart';
 import 'package:mobile_ai_erp/domain/usecase/web_builder/get_cms_page_by_id_usecase.dart';
 import 'package:mobile_ai_erp/domain/usecase/web_builder/get_cms_pages_usecase.dart';
+import 'package:mobile_ai_erp/domain/usecase/web_builder/publish_cms_page_usecase.dart';
 import 'package:mobile_ai_erp/domain/usecase/web_builder/save_cms_page_usecase.dart';
 import 'package:mobx/mobx.dart';
 
@@ -18,6 +19,7 @@ abstract class _CmsPageStore with Store {
     this._getCmsPageByIdUseCase,
     this._saveCmsPageUseCase,
     this._deleteCmsPageUseCase,
+    this._publishCmsPageUseCase,
     this.errorStore,
   );
 
@@ -26,6 +28,7 @@ abstract class _CmsPageStore with Store {
   final GetCmsPageByIdUseCase _getCmsPageByIdUseCase;
   final SaveCmsPageUseCase _saveCmsPageUseCase;
   final DeleteCmsPageUseCase _deleteCmsPageUseCase;
+  final PublishCmsPageUseCase _publishCmsPageUseCase;
 
   // stores:--------------------------------------------------------------------
   final ErrorStore errorStore;
@@ -86,6 +89,19 @@ abstract class _CmsPageStore with Store {
   Future deletePage(String id) async {
     try {
       await _deleteCmsPageUseCase.call(params: id);
+      success = true;
+      await getPages();
+    } catch (error) {
+      errorStore.errorMessage = error.toString();
+    }
+  }
+
+  @action
+  Future publishPage(String id, bool published) async {
+    try {
+      await _publishCmsPageUseCase.call(
+        params: PublishCmsPageParams(id: id, published: published),
+      );
       success = true;
       await getPages();
     } catch (error) {


### PR DESCRIPTION
## Summary

Integrate the Phase 2 Web Builder backend APIs (Store Settings, CMS Pages, Themes) into the existing `web_builder` module. Replaces all 3 mock repositories with real HTTP calls and adds the publish/unpublish workflow for CMS pages.

Pairs with the backend PR `feat/ticket-57/web-builders` (myjarvis/ai-erp-be) which exposes the 11 endpoints consumed here.

## What's new

### 🔌 Network layer (Apr 24)
- `ERP_BASE_URL` and `TENANT_ID` env-driven constants in `endpoints.dart`
- `TenantInterceptor` injects `X-Tenant-Id` header on every request, logs a warning if started with the placeholder zeros UUID
- Separate named DioClient (`'erpDioClient'`) for the ERP backend, wired with Auth + Tenant + Error + Logging interceptors
- `WebBuilderApi` with 11 methods covering all 3 modules

### 🛍️ Store Settings + Themes (Apr 25)
- `StoreSettingsRepositoryImpl` calls `GET/PATCH /store-settings`, maps BE `name`/`contactEmail`/`contactPhone`/`logoUrl` ↔ FE `storeName`/`email`/`phone`/`logoUrl`
- `WebThemeRepositoryImpl` fetches `/themes` and `/themes/active` in parallel, parses hex color strings into ARGB ints, derives `backgroundColor` from primary color (dark category → dark neutral, otherwise tint 92% toward white since BE has no background field)
- `applyTheme` logs a warning when caller passes color overrides since BE doesn't yet support per-tenant custom colors

### 📄 CMS Pages (Apr 26)
- Full CRUD via `WebBuilderApi`: list with pagination + status filter, get by id, create, partial update, soft delete, publish/unpublish
- `getPageById` only swallows 404 `DioException`; other errors propagate
- `CmsPageStatus.published`/`draft` constants replace inline magic strings
- New `PublishCmsPageUseCase` (with `PublishCmsPageParams { id, published }`) wired through the use case module

### 🎬 Store action (Apr 27)
- `CmsPageStore.publishPage(id, published)` action calls the use case and refreshes the page list on success

## Field mappings (BE camelCase ↔ FE entity)

| BE response | FE entity |
|---|---|
| `name`, `contactEmail`, `contactPhone`, `logoUrl` | `storeName`, `email`, `phone`, `logoUrl` |
| `pageType`, `urlSlug`, `contentBlocks`, `isPublished`, `updatedAt` | `type`, `slug`, `blocks`, `isPublished`, `lastModified` |
| `primaryColor`/`accentColor` (hex string `#RRGGBB`) | `primaryColor`/`accentColor` (ARGB int) |
| `fontHeading` + `fontBody` | `fonts` (List<String>) |

## Runtime config

```bash
flutter run \
  --dart-define=ERP_BASE_URL=http://10.0.2.2:3000 \
  --dart-define=TENANT_ID=<your-tenant-uuid>
